### PR TITLE
Add overlooked characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ We use lots of symbols in code. However, names for these symbols are often long 
 - `{`: open curly brace → o-cur ("ochre")
 - `}`: close curly brace → c-cur ("seeker")
 - `~`: tilde → curl
+- `w`: double u → dub
+- `7`: seven → sev
+- `11`: eleven → lev (as in "bush did nine lev")
+- `🥦`: broccoli → brocc
+- `🐒`: monkey → 猴（"猴")


### PR DESCRIPTION
Most notably, certain standard characters were missing from the first version.
- `w` is such an egregiously named character. I opted to propose "dub" do to its existing prominence, but "wub" is an interesting alternative. In the end, I think intuitiveness (people are familiar with "dub") is more important than linguistic consistency (double-u has no relation to the sound `w` makes).
- `7` is a standard key and the only digit with a multi-syllabic English pronunciation
- `11` is basically a digit, considering how often it is used. Below are some examples.
	- "Let's go to 7/11."
	- "Remember what Hasan said about 9/11?"
	- "Contrary to what some Minecraft youtubers believe, the age of consent is above 11."
- `🥦` is self explanatory.
- `🐒` and many other symbols can be referred to by their mono-syllabic names in other languages.